### PR TITLE
BIOSYS-429 - mailto link

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="42" id="au.gov.nsw.dpie.koalawatch" ios-CFBundleIdentifier="au.gov.nsw.dpie.ispykoala" ios-CFBundleVersion="6" version="1.1.5" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="43" id="au.gov.nsw.dpie.koalawatch" ios-CFBundleIdentifier="au.gov.nsw.dpie.ispykoala" ios-CFBundleVersion="6" version="1.1.5" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>I Spy Koala</name>
     <description>App for surveying koala populations</description>
     <author email="devs@gaiaresources.com.au" href="https://www.gaiaresources.com.au">Gaia Resources</author>

--- a/src/pages/privacy-policy/privacy-policy.html
+++ b/src/pages/privacy-policy/privacy-policy.html
@@ -202,7 +202,7 @@
         <p>Phone: 02 9860 1440</p>
         <p></p>
         <p>
-            Email: privacy@dpie.nsw.gov.au
+          Email: <a href="mailto:privacy@dpie.nsw.gov.au">privacy@dpie.nsw.gov.au</a>
         </p>
 
         <p>

--- a/src/shared/utils/consts.ts
+++ b/src/shared/utils/consts.ts
@@ -210,7 +210,7 @@ export let SIGNUP_TERMS_AND_CONDITIONS_HTML = `
 <p>Phone: 02 9860 1440</p>
 <p></p>
 <p>
-    Email: privacy@dpie.nsw.gov.au
+  Email: <a href="mailto:privacy@dpie.nsw.gov.au">privacy@dpie.nsw.gov.au</a>
 </p>
 
 <p>


### PR DESCRIPTION
"The previous email address line was as follows:

Email: mailto:patiunit@planning.nsw.gov.au 

 

The email address line should be:

Email: privacy@dpie.nsw.gov.au

 

So, the link is required, however the ‘mailto:’ is not required and the address has changed. With the mailto: included the email fails to send."